### PR TITLE
ZCS-2592

### DIFF
--- a/js/com_zimbra_tooltip_fr.properties
+++ b/js/com_zimbra_tooltip_fr.properties
@@ -14,12 +14,12 @@
 # If not, see <https://www.gnu.org/licenses/>.
 # ***** END LICENSE BLOCK *****
 #
-label =  Info-bulle d'aide
-description = Extension d'administration d'info-bulle d'aide
+label =  Info-bulle d\u2019aide
+description = Extension d\u2019administration d\u2019info-bulle d\u2019aide
 llMore = Suite
 llHide = Masquer
-llAttributeName = Nom d'attribut
+llAttributeName = Nom d\u2019attribut
 llDesc = Description
 llLoading = Chargement
-llNoResult = Aucune description n'a \u00e9t\u00e9 trouv\u00e9e
+llNoResult = Aucune description n\u2019a \u00e9t\u00e9 trouv\u00e9e
 BUSY_GET_DESC = Obtention de la description...


### PR DESCRIPTION
- Use smart quotes (\u2019/ - \u2018/\u2019 ) instead of single quotes in translation files
- minor fixes with spacing/quote&formatting tag pairing